### PR TITLE
Make the search icon not platform dependent

### DIFF
--- a/src/ion-autocomplete.js
+++ b/src/ion-autocomplete.js
@@ -61,7 +61,7 @@ angular.module('ion-autocomplete', []).directive('ionAutocomplete', [
                     '<div class="ion-autocomplete-container modal">',
                     '<div class="bar bar-header item-input-inset">',
                     '<label class="item-input-wrapper">',
-                    '<i class="icon ion-ios7-search placeholder-icon"></i>',
+                    '<i class="icon ion-search placeholder-icon"></i>',
                     '<input type="search" class="ion-autocomplete-search" ng-model="searchQuery" placeholder="{{placeholder}}"/>',
                     '</label>',
                     '<button class="ion-autocomplete-cancel button button-clear">{{cancelLabel}}</button>',

--- a/test/ion-autocomplete.single-select.spec.js
+++ b/test/ion-autocomplete.single-select.spec.js
@@ -79,6 +79,10 @@ describe('ion-autocomplete single select', function () {
         expect(searchInputElement.hasClass('ion-autocomplete-search')).toBe(true);
         expect(searchInputElement[0].placeholder).toBe('Click to enter a value...');
 
+        // expect the placeholder icon element to no be platform dependent
+        var placeholderIcon = getPlaceholderIconElement();
+        expect(placeholderIcon.hasClass('ion-search')).toBe(true);
+
         // expect the default values of the cancel button
         var cancelButtonElement = getCancelButtonElement();
         expect(cancelButtonElement.hasClass('button')).toBe(true);
@@ -303,6 +307,14 @@ describe('ion-autocomplete single select', function () {
      */
     function getSearchContainerElement() {
         return angular.element(document[0].querySelector('div.ion-autocomplete-container'))
+    }
+
+    /**
+     * Gets the angular element for the autocomplete placer holder icon
+     * @returns {*} the search placeholder icon element
+     */
+    function getPlaceholderIconElement() {
+        return angular.element(document[0].querySelector('i.placeholder-icon'))
     }
 
     /**


### PR DESCRIPTION
At the moment, the search icon is not visible.
The ion-ios7-search does not exist anymore.
I suggest to replace it by the more generic icon: ion-search.