### PR TITLE
Support for new valueFormat attribute

### DIFF
--- a/src/ion-autocomplete.js
+++ b/src/ion-autocomplete.js
@@ -21,7 +21,8 @@ angular.module('ion-autocomplete', []).directive('ionAutocomplete', [
                 itemsRemovedMethod: '&',
                 componentId: '@',
                 modelToItemMethod: '&',
-                loadingIcon: '@'
+                loadingIcon: '@',
+				valueFormat: '@'
             },
             link: function (scope, element, attrs, ngModel) {
 
@@ -347,7 +348,16 @@ angular.module('ion-autocomplete', []).directive('ionAutocomplete', [
 
                 // render the view value of the model
                 ngModel.$render = function () {
-                    element.val(scope.getItemValue(ngModel.$viewValue, scope.itemViewValueKey));
+					if (scope.valueFormat) {
+						if (ngModel.$viewValue != '') {
+							var val = scope.valueFormat.replace(/\{(\w+)\}/g, function (a, prop) {
+								return scope.getItemValue(ngModel.$viewValue, scope.itemViewValueKey)[prop];
+							});
+							element.val(val);
+						}
+					}
+					else
+						element.val(scope.getItemValue(ngModel.$viewValue, scope.itemViewValueKey));
                 };
 
                 // set the view value of the model


### PR DESCRIPTION
Proposal to include new "valueFormat" attribute to ion-autocomplete to allow formatting of a complex model which is bound through `items-method`.
It could be utilised in such a way:

```
<ion-autocomplete ng-model="model.AddressCity"
	item-value-key="name"
	item-view-value-key="view"
	items-method="getCityQuery(query)"
	items-method-value-key="items"
	multiple-select="false"
	placeholder="Enter City or Postcode..."
	select-items-label="Select city..."
	items-clicked-method="itemsClicked(callback)"
	value-format="{City}, {State}"
	template-url="templates/city-select.html" />
```