### PR TITLE
introduce selectedItemsRenderMethod and -Separator

### DIFF
--- a/src/ion-autocomplete.js
+++ b/src/ion-autocomplete.js
@@ -18,7 +18,9 @@ angular.module('ion-autocomplete', []).directive('ionAutocomplete', [
                 placeholder: '@',
                 cancelLabel: '@',
                 selectItemsLabel: '@',
-                selectedItemsLabel: '@'
+                selectedItemsLabel: '@',
+                selectedItemsSeparator: '@',
+                selectedItemsRenderMethod: '&'
             },
             controllerAs: 'viewModel',
             controller: function ($attrs, $timeout) {
@@ -35,6 +37,7 @@ angular.module('ion-autocomplete', []).directive('ionAutocomplete', [
                     controller.cancelLabel = valueOrDefault(controller.cancelLabel, 'Done');
                     controller.selectItemsLabel = valueOrDefault(controller.selectItemsLabel, "Select an item...");
                     controller.selectedItemsLabel = valueOrDefault(controller.selectedItemsLabel, $interpolate("Selected items{{maxSelectedItems ? ' (max. ' + maxSelectedItems + ')' : ''}}:")(controller));
+                    controller.selectedItemsSeparator = valueOrDefault(controller.selectedItemsSeparator, ',');
                 });
 
                 // set the default values of the passed in attributes
@@ -46,7 +49,8 @@ angular.module('ion-autocomplete', []).directive('ionAutocomplete', [
                 this.componentId = valueOrDefault($attrs.componentId, undefined);
                 this.loadingIcon = valueOrDefault($attrs.loadingIcon, undefined);
                 this.manageExternally = valueOrDefault($attrs.manageExternally, "false");
-
+                this.selectedItemsSeparator = valueOrDefault($attrs.selectedItemsSeparator, ',');
+                this.hasSelectedItemsRenderMethod = !!($attrs['selectedItemsRenderMethod']);
                 // loading flag if the items-method is a function
                 this.showLoadingIcon = false;
 
@@ -395,7 +399,19 @@ angular.module('ion-autocomplete', []).directive('ionAutocomplete', [
 
                 // render the view value of the model
                 ngModelController.$render = function () {
-                    element.val(ionAutocompleteController.getItemValue(ngModelController.$viewValue, ionAutocompleteController.itemViewValueKey));
+                    var itemValue = ionAutocompleteController.getItemValue(ngModelController.$viewValue, ionAutocompleteController.itemViewValueKey);
+                    var displayValue = undefined;
+
+                    if (ionAutocompleteController.hasSelectedItemsRenderMethod && angular.isFunction(ionAutocompleteController.selectedItemsRenderMethod)) {
+                        displayValue = ionAutocompleteController.selectedItemsRenderMethod({items: itemValue});
+                    }
+                    else if (typeof itemValue === 'object' ) {
+                        displayValue = itemValue.join(ionAutocompleteController.selectedItemsSeparator || ",");
+                    }
+                    else {
+                        displayValue = itemValue;
+                    }
+                    element.val(displayValue);
                 };
 
                 // set the view value of the model


### PR DESCRIPTION
hey @guylabs,

i never enjoyed that all the item-values are just comma-separated.

with this addition, you have 2 new attributes, first of which is `selected-items-separator`, which replaces the `,`, and for more fancy outcome you can specify a method, e.g. to have element values like "Item 1, Item2 & Item3"

------
however, i dont know what i messed up but angular.isFunction was _always_ true to me, independent of the actually presence of that attribute. so i added this hasSelectedItemsRenderMethod property.

------

example usage:

```html
<input ion-autocomplete selected-items-separator="  -  " ... />
```
will  show not `A,B,C` but `A - B - C`

```html
<input ion-autocomplete selected-items-render-method="pretty_sentence(items)" ... />
```
```coffee
$scope.pretty_sentence = (items) ->
        names = _.sortBy items, (i) -> i
        last  = names.pop()
        ret   = names.join ', '
        ret += ' & ' if names.length > 0
        ret += last
```
will show `A, B & C`

well,  what do you think?
cheers.