### PR TITLE
prevent showing popup if disabled

### DIFF
--- a/src/ion-autocomplete.js
+++ b/src/ion-autocomplete.js
@@ -325,6 +325,10 @@ angular.module('ion-autocomplete', []).directive('ionAutocomplete', [
 
                     // store the start coordinates of the touch start event
                     var onTouchStart = function (e) {
+                        if (element.attr("disabled")) {
+                            return;
+                        }
+
                         scrolling.moved = false;
                         // Use originalEvent when available, fix compatibility with jQuery
                         if (typeof(e.originalEvent) !== 'undefined') {
@@ -336,6 +340,10 @@ angular.module('ion-autocomplete', []).directive('ionAutocomplete', [
 
                     // check if the finger moves more than 10px and set the moved flag to true
                     var onTouchMove = function (e) {
+                        if (element.attr("disabled")) {
+                            return;
+                        }
+
                         // Use originalEvent when available, fix compatibility with jQuery
                         if (typeof(e.originalEvent) !== 'undefined') {
                             e = e.originalEvent;
@@ -348,6 +356,10 @@ angular.module('ion-autocomplete', []).directive('ionAutocomplete', [
 
                     // click handler on the input field to show the search container
                     var onClick = function (event) {
+                        if (element.attr("disabled")) {
+                            return;
+                        }
+
                         // only open the dialog if was not touched at the beginning of a legitimate scroll event
                         if (scrolling.moved) {
                             return;


### PR DESCRIPTION
hi do you think this is a reasonable change?
having a disabled input on the browser prevents the popup from showing, but doesn't seem to prevent it on android (crosswalk).

