### PR TITLE
hotfix for css cardinality bug

### DIFF
--- a/src/ion-autocomplete.css
+++ b/src/ion-autocomplete.css
@@ -1,4 +1,4 @@
-.ion-autocomplete-container {
+.modal.ion-autocomplete-container {
     position: fixed;
     top: 0;
     right: 0;
@@ -9,7 +9,7 @@
     margin: auto;
 }
 
-input.ion-autocomplete[readonly] {
+input.ion-autocomplete[readonly]:not(.cloned-text-input), {
     background-color: transparent;
     cursor: text;
 }


### PR DESCRIPTION
this is a hotfix for some ionic defaults that override the ion-autocomplete stylings if we reference css order in index like following:

1. lib.bundle.css => all css files in lib bundled together and minified
2. app.bundle.css => all css files that are app depending (starting with ionic bundle) bundled together and minified