### PR TITLE
Update pointer-events rule

### DIFF
--- a/src/ion-autocomplete.css
+++ b/src/ion-autocomplete.css
@@ -7,6 +7,7 @@
     z-index: 20;
     display: none;
     margin: auto;
+    pointer-events:auto;
 }
 
 input.ion-autocomplete[readonly] {


### PR DESCRIPTION
This is necessary ..at least when the directive is called inside a ionicModal, or the directive's modal cannot be interacted with.